### PR TITLE
Fixed package.json repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "swagger-mod-security",
+  "description": "Transform swagger schema by filtering paths",
   "version": "0.0.1",
-  "main": "index.js",
-  "repository": "git@github.com:Countingup/swagger-mod-security.git",
-  "author": "Patrick Curry <patrick.curry@countingup.com>",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Countingup/swagger-mod-security.git"
+  },
+  "author": "Patrick Curry",
   "license": "MIT",
+  "main": "index.js",
   "scripts": {
     "test": "jest src",
     "fmt": "prettier --write \"**/*.md\" && prettier --write \"./**/*.js\"",
@@ -34,5 +38,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "keywords": ["swagger"]
 }


### PR DESCRIPTION
https://www.npmjs.com/package/swagger-mod-security will now show a repository link.