### PR TITLE
Change filter to allow all routes with no security

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "printWidth": 120,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "singleQuote": false
 }

--- a/src/filter.js
+++ b/src/filter.js
@@ -7,6 +7,10 @@ exports.includeOnly = (authKey, acceptedRoles, schema) => {
         .map(path => {
           return path.filter(operation => {
             const security = (operation.get("security") || Immutable.List()).toJS();
+            if (security.length === 0) {
+              return true; // No security = most permissive so should always be included
+            }
+
             for (let i = 0; i < security.length; i++) {
               const auth = security[i];
               const roles = auth[authKey];

--- a/src/filter.test.js
+++ b/src/filter.test.js
@@ -95,7 +95,7 @@ describe("includeOnly", () => {
   it("should return empty for unrecognised auth", () => {
     expect(includeOnly("unrecognised", ["role1"], schema())).to.deep.equal(emptySchema());
   });
-  it("should exclude routes with missing security", () => {
-    expect(includeOnly("auth_jwt", ["role1"], schemaWithMissingSecurity())).to.deep.equal(emptySchema());
+  it("should include routes with missing security", () => {
+    expect(includeOnly("auth_jwt", ["role1"], schemaWithMissingSecurity())).to.deep.equal(schemaWithMissingSecurity());
   });
 });


### PR DESCRIPTION
Routes with no security are probably callable by all clients but they're currently filtered out. This PR reverses that so all security-less routes are included in the generated client.

Also a change to the prettier config as it didn't match the current code and my VSCode overwrote everything